### PR TITLE
Completed error handling issue in item.repository and user.repository

### DIFF
--- a/src/api/routes/auth.routes.ts
+++ b/src/api/routes/auth.routes.ts
@@ -2,4 +2,7 @@ import express from "express";
 
 const authRouter = express.Router();
 
+
+
+
 export default authRouter;

--- a/src/api/routes/items.routes.ts
+++ b/src/api/routes/items.routes.ts
@@ -1,5 +1,7 @@
 import express from "express";
 
-const authRouter = express.Router();
+const itemRouter = express.Router();
 
-export default authRouter;
+
+
+export default itemRouter;

--- a/src/api/routes/user.routes.ts
+++ b/src/api/routes/user.routes.ts
@@ -1,5 +1,8 @@
 import express from "express";
 
-const authRouter = express.Router();
+const userRouter = express.Router();
 
-export default authRouter;
+
+
+
+export default userRouter;

--- a/src/models/message.repository.ts
+++ b/src/models/message.repository.ts
@@ -1,0 +1,25 @@
+import { User, Message, Chat } from "./models";
+
+export const getChats = async (username: string) => {
+    const chats = await Chat.findAll({
+        where: {
+            senderId: username,
+        },
+    });
+    return chats;
+};
+
+
+export const getUserMessages = async (user1: User, user2: User) => {
+    const messages = await Message.findAll({
+        where: {
+            senderId: user1.username,
+            recipientId: user2.username
+        },
+        order: [    
+            ['createdAt', 'ASC']
+        ]
+    });
+    return messages;
+};
+

--- a/src/models/models.ts
+++ b/src/models/models.ts
@@ -10,12 +10,13 @@ import {
   ForeignKey,
 } from "sequelize";
 
-/** @desc Initialize User model */
+
 export class User extends Model<
   InferAttributes<User, { omit: "items" }>,
   InferCreationAttributes<User, { omit: "items" }>
 > {
   declare username: string;
+  declare fullName: string;
   declare email: string;
   declare password: string;
   declare userBio: string;
@@ -28,10 +29,13 @@ export class User extends Model<
 
   declare items?: NonAttribute<Item[]>;
 
-  declare static associations: { items: Association<User, Item> };
+  declare static associations: { 
+    items: Association<User, Item>,
+    senderMsgs: Association<User, Message>,
+    recipientMsgs: Association<User, Message>
+  };
 }
 
-/** @desc Initialize Item model */
 export class Item extends Model<
   InferAttributes<Item>,
   InferCreationAttributes<Item>
@@ -42,14 +46,83 @@ export class Item extends Model<
   declare userId: ForeignKey<User["username"]>;
   declare itemPhotos: string[];
   declare owner?: NonAttribute<User>;
-  declare postDate: CreationOptional<Date>;
+
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+
+  /*
+  get getOwner(): NonAttribute<User> {
+    return this.owner;
+  }
+  */ 
 }
 
+export class Message extends Model<
+  InferAttributes<Message>,
+  InferCreationAttributes<Message>
+> {
+  declare messageId: CreationOptional<number>;
+  declare message: string;
+  declare senderId: ForeignKey<User["username"]>;
+  declare recipientId: ForeignKey<User["username"]>;
+  declare createdAt: CreationOptional<Date>;
+}
+
+export class Wishlist extends Model<
+  InferAttributes<Wishlist>,
+  InferCreationAttributes<Wishlist>
+> {
+  declare userId: ForeignKey<User["username"]>;
+  declare itemId: ForeignKey<Item["itemId"]>;
+}
+
+export class Chat extends Model<
+  InferAttributes<Chat>,
+  InferCreationAttributes<Chat>
+> {
+  declare senderId: ForeignKey<User["username"]>;
+  declare recipientId: ForeignKey<User["username"]>;
+  declare createdAt: CreationOptional<Date>;
+  declare updatedAt: CreationOptional<Date>;
+}
+
+Chat.init(
+  {
+    senderId: {
+      type: DataTypes.STRING,
+      primaryKey: true
+    },
+    recipientId: {
+      type: DataTypes.STRING,
+      primaryKey: true
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    }
+  },
+  {
+    sequelize,
+    modelName: "Chat",
+    tableName: "chats",
+  }
+)
+
+
+/** @desc Initialize User model */
 User.init(
     {
         username: {
             type: DataTypes.STRING,
             primaryKey: true, 
+        },
+        fullName: {
+            type: DataTypes.STRING,
+            primaryKey: true,
         },
         email: {
             type: DataTypes.STRING,
@@ -88,6 +161,7 @@ User.init(
     }
 );
 
+/** @desc Initialize Item model */
 Item.init(
   {
     itemId: {
@@ -103,27 +177,75 @@ Item.init(
       type: DataTypes.FLOAT,
       allowNull: false,
     },
-    userId: {
-      type: DataTypes.INTEGER,
-      allowNull: false,
-    },
-    postDate:{
-      type: DataTypes.DATE,
-      allowNull: false,
-    },
     itemPhotos: {
         type: DataTypes.ARRAY(DataTypes.STRING),
         allowNull: true,
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
+    },
+    updatedAt: {
+      type: DataTypes.DATE,
+      allowNull: false,
     }
   },
   {
     sequelize,
     modelName: "Item",
     tableName: "items",
-    createdAt: false,
+  }
+);
+
+/** @desc initialize Message model */
+Message.init(
+  {
+    messageId: {
+      type: DataTypes.INTEGER,
+      autoIncrement: true,
+      primaryKey: true
+    },
+    message: {
+      type: DataTypes.STRING,
+      allowNull: false
+    },
+    createdAt: {
+      type: DataTypes.DATE,
+      allowNull: false
+    }
+  },
+  {
+    sequelize,
+    modelName: "User",
+    tableName: "users",
     updatedAt: false,
   }
 );
+
+/** @desc initialize Wishlist model */
+Wishlist.init(
+  {
+    userId: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      primaryKey: true,
+    }, 
+    itemId: {
+      type: DataTypes.NUMBER,
+      allowNull: false,
+      primaryKey: true, 
+    }
+  },
+  {
+      sequelize,
+      modelName: "Wishlist",
+      tableName: "Wishlists",
+  }
+);
+
+
+/** @desc Associations go here */
+
 User.hasMany(Item, {
   foreignKey: "userId",
   sourceKey: "username",
@@ -133,3 +255,25 @@ User.hasMany(Item, {
 Item.belongsTo(User, {
   targetKey: "username",
 });
+
+User.hasMany(Message, { 
+  foreignKey: "senderId",
+  sourceKey: "username",
+  as: "senderMsgs"
+});
+
+User.hasMany(Message, {
+  foreignKey: "recipientId",
+  sourceKey: "username",
+  as: "recipientMsgs"
+});
+
+Message.belongsTo(User, {
+  targetKey: "username"
+});
+
+User.belongsToMany(Item, {through: "Wishlist"});
+
+Item.belongsToMany(User, {through: "Wishlist"});
+
+

--- a/src/models/user.repository.ts
+++ b/src/models/user.repository.ts
@@ -88,3 +88,4 @@ export const createItem = async (
   });
   return newItem;
 };
+


### PR DESCRIPTION
I updated createUser to call userExists instead of querying with findOne so any user error checking is checked in userExists. I added this to all of the user functions. I also updated item.repository to have an itemExists check to ensure the item exists before trying to update or delete an item. Needs review for correctness